### PR TITLE
Add unit tests for CreateProductHandler and update SaleItem and Sale …

### DIFF
--- a/tests/UnitTests/Application/Features/Products/Handlers/CreateProductHandlerTest.cs
+++ b/tests/UnitTests/Application/Features/Products/Handlers/CreateProductHandlerTest.cs
@@ -1,0 +1,70 @@
+using AutoMapper;
+using DeveloperStore.Application.Features.Products.Commands;
+using DeveloperStore.Application.Features.Products.Dtos;
+using DeveloperStore.Application.Features.Products.Handlers;
+using DeveloperStore.Domain.Entities;
+using DeveloperStore.Domain.Repositories;
+using DeveloperStore.Domain.ValueObjects;
+using MediatR;
+using NSubstitute;
+using SharpAbp.Abp.Snowflakes;
+using Xunit;
+
+namespace DeveloperStore.Application.Features.Products.Handlers.Tests;
+
+public class CreateProductHandlerTest
+{
+    private readonly IProductRepository _productRepositoryMock;
+    private readonly IMapper _mapperMock;
+    private readonly Snowflake _snowflakeMock;
+    private readonly CreateProductHandler _handler;
+
+    public CreateProductHandlerTest()
+    {
+        _productRepositoryMock = Substitute.For<IProductRepository>();
+        _mapperMock = Substitute.For<IMapper>();
+        _snowflakeMock = new Snowflake(workerId: 1, datacenterId: 1);
+        _handler = new CreateProductHandler(_productRepositoryMock, _mapperMock, _snowflakeMock);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnProductDto_WhenProductIsCreatedSuccessfully()
+    {
+        // Arrange
+        var command = new CreateProductCommand { Title = "Test Product", Price = 100 };
+        var productId = 123456789L;
+        var product = new Product(productId, "Test Product", description: "Descr Test", 100M, "category", new Rating(5, 10), image: null);         
+        var productDto = new ProductDto { Id = productId, Title = "Test Product", Price = 100 };
+        
+        _mapperMock.Map<CreateProductCommand, Product>(command).Returns(product);
+        _productRepositoryMock.AddAsync(product, Arg.Any<CancellationToken>()).Returns(product);
+        _mapperMock.Map<Product, ProductDto>(product).Returns(productDto);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(productDto.Id, result.Id);
+        Assert.Equal(productDto.Title, result.Title);
+        Assert.Equal(productDto.Price, result.Price);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnNull_WhenProductCreationFails()
+    {
+        // Arrange
+        var command = new CreateProductCommand { Title = "Test Product", Price = 100 };
+        var productId = 123456789L;
+        var product = new Product(productId, "Test Product", description: "Descr Test", 100M, "category", new Rating(5, 10), image: null);      
+        
+        _mapperMock.Map<CreateProductCommand, Product>(command).Returns(product);
+        _productRepositoryMock.AddAsync(product, Arg.Any<CancellationToken>()).Returns((Product?)null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/tests/UnitTests/Domain/Entities/SaleItemTests.cs
+++ b/tests/UnitTests/Domain/Entities/SaleItemTests.cs
@@ -10,7 +10,7 @@ public class SaleItemTest
     private readonly Product _product;
     public SaleItemTest()
     {
-        _product = new Product(1, "Test Product", "Test Description", 50, "Category", null);        
+        _product = new Product(1, "Test Product", "Test Description", 50, "Category", new Rating(4.5, 100));        
     }
 
     [Fact]

--- a/tests/UnitTests/Domain/Entities/SaleTests.cs
+++ b/tests/UnitTests/Domain/Entities/SaleTests.cs
@@ -30,7 +30,7 @@ public class SaleTest
     public void Constructor_ShouldCreateValidSale()
     {
         // Arrange & Act
-        var saleDate = DateTime.Now;
+        var saleDate = DateTime.Now.ToUniversalTime();
         var sale = new Sale(_snowflakeIdGenerator.NextId(),_customer, _branch, saleDate);
 
         // Assert

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -11,13 +11,16 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="SharpAbp.Abp.Snowflakes" Version="4.1.3" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Domain\Domain.csproj" />
+    <ProjectReference Include="..\..\src\Application\Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

This pull request includes several updates to unit tests and project dependencies, primarily focusing on adding new tests for the `CreateProductHandler` and updating existing tests to improve accuracy and consistency.

### New Tests:
* Added `CreateProductHandlerTest` class to test the `CreateProductHandler` functionality. This includes tests for successful product creation and handling of failed product creation. (`tests/UnitTests/Application/Features/Products/Handlers/CreateProductHandlerTest.cs`)

### Updates to Existing Tests:
* Updated `SaleItemTest` to include a `Rating` object when initializing a `Product` instance. (`tests/UnitTests/Domain/Entities/SaleItemTests.cs`)
* Modified `SaleTest` to use `DateTime.Now.ToUniversalTime()` for setting the sale date to ensure consistency across different time zones. (`tests/UnitTests/Domain/Entities/SaleTests.cs`)

### Project Dependencies:
* Added `NSubstitute` and `AutoMapper` package references to the unit test project for mocking and object mapping purposes. (`tests/UnitTests/UnitTests.csproj`)
* Included a project reference to the `Application` project to access application layer classes in tests. (`tests/UnitTests/UnitTests.csproj`)